### PR TITLE
Fix linking issue on KaNaPi Linux

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ CFLAGS := $(DEFS) -O3 -fomit-frame-pointer -Winline -DNDEBUG
 #CFLAGS := $(DEFS) -ggdb -DRTH_NDEBUG
 
 
-LIBS   := -lm -lpng -lz -lgmp -lmpfr -lpthread
+LIBS   := -lm -lpng -lz -lgmp -lmpfr -lpthread -ldl -lresolv -lrt
 
 SRC    := $(wildcard *.c)
 OBJS   := $(patsubst %.c, %.o, $(SRC))


### PR DESCRIPTION
/kanapi_0.10/packages/glib-2.51.0/lib/libgmodule-2.0.so.0: undefined reference to `dlsym@GLIBC_2.2.5'
/kanapi_0.10/packages/glib-2.51.0/lib/libgio-2.0.so: undefined reference to `__dn_expand@GLIBC_2.2.5'
/kanapi_0.10/packages/glib-2.51.0/lib/libgmodule-2.0.so.0: undefined reference to `dlerror@GLIBC_2.2.5'
/kanapi_0.10/packages/glib-2.51.0/lib/libgio-2.0.so: undefined reference to `__res_query@GLIBC_2.2.5'
/kanapi_0.10/packages/glib-2.51.0/lib/libgmodule-2.0.so.0: undefined reference to `dlclose@GLIBC_2.2.5'
/kanapi_0.10/packages/glib-2.51.0/lib/libgmodule-2.0.so.0: undefined reference to `dlopen@GLIBC_2.2.5'
/kanapi_0.10/packages/cairo-1.14.12/lib/libcairo.so: undefined reference to `clock_gettime@GLIBC_2.2.5'

Signed-off-by: Jacek Danecki <jacek.m.danecki@gmail.com>